### PR TITLE
[IMP] odoo-print: Add number of copies to qweb-cpcl templates

### DIFF
--- a/addons/print/models/print_printer.py
+++ b/addons/print/models/print_printer.py
@@ -185,13 +185,19 @@ class Printer(models.Model):
             raise UserError(_("Missing reports of types: %s") %
                             ', '.join(missing))
 
+        # CPCL reports require number of copies passed into the template via data
+        cpcl_data = {'copies': copies}
+        if data:
+            cpcl_data.update(data)
+
         # Generate reports for each required report type
         documents = {
             x.report_type: (
                 ("%s %s" % (x.name, str(docids))) if title is None else title,
-                x.render(docids, data)[0]
+                x.render(docids, cpcl_data if x.report_type == "qweb-cpcl" else data)[0],
             )
-            for x in reports if x.report_type in required
+            for x in reports
+            if x.report_type in required
         }
 
         # Send appropriate report to each printer

--- a/addons/print/tests/files/dotmatrix_test_page_qty2.xml
+++ b/addons/print/tests/files/dotmatrix_test_page_qty2.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<cpcl xmlns="http://www.fensystems.co.uk/xmlns/cpcl">
+  <print height="50" qty="2">
+    <in-millimeters/>
+    <center/>
+    <contrast>3</contrast>
+    <text y="1" size="2">Printer Test Page</text>
+    <barcode y="10" width="0.5" height="20">DOTMATRIX</barcode>
+    <text y="33" size="2">Dot matrix</text>
+    <form/>
+  </print>
+</cpcl>

--- a/addons/print/tests/files/dotmatrix_test_page_qty5.xml
+++ b/addons/print/tests/files/dotmatrix_test_page_qty5.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<cpcl xmlns="http://www.fensystems.co.uk/xmlns/cpcl">
+  <print height="50" qty="5">
+    <in-millimeters/>
+    <center/>
+    <contrast>3</contrast>
+    <text y="1" size="2">Printer Test Page</text>
+    <barcode y="10" width="0.5" height="20">DOTMATRIX</barcode>
+    <text y="33" size="2">Dot matrix</text>
+    <form/>
+  </print>
+</cpcl>


### PR DESCRIPTION
Adding in copies into the print statements of cpcl templates
automatically. CPCL requires the number of labels to be sent
as part of the CPCL itself - passing qty to LPR has no effect.