### PR TITLE
Story/10476 - Allow one user default printer per report type

### DIFF
--- a/addons/print/models/res_users.py
+++ b/addons/print/models/res_users.py
@@ -11,25 +11,26 @@ class User(models.Model):
     _inherit = 'res.users'
 
     printer_ids = fields.Many2many('print.printer', string="Default Printers")
-    printer_id = fields.Many2one('print.printer', string="Default Printer",
-                                 compute='_compute_printer_id', store=True)
 
-    @api.multi
-    @api.depends('printer_ids')
-    def _compute_printer_id(self):
-        """Compute default ungrouped printer (for backwards compatibility)"""
-        for user in self:
-            user.printer_id = user.printer_ids.filtered(
-                lambda x: not x.group_id
-            )
+    def get_printer(self, report_type=None):
+        """
+        Identify and return user default ungrouped printer (for backwards compatibility) 
+        for report type (if specified)
+        """
+        self.ensure_one()
+        printer = self.printer_ids.filtered(
+            lambda p: not p.group_id and (report_type is None or p.report_type == report_type)
+        )
+        # If multiple printers are found, return the first one
+        return printer[:1]
 
     @api.multi
     @api.constrains('printer_ids')
     def _check_printer_ids(self):
-        """Constrain user to having one default printer per group"""
+        """Constrain user to having one default printer per group, for each report type"""
         for user in self:
-            groups = set(x.group_id for x in user.printer_ids)
-            if len(user.printer_ids) != len(groups):
-                raise ValidationError(_(
-                    "User may have at most one default printer per group"
-                ))
+            groups_by_report_type = set((p.group_id, p.report_type) for p in user.printer_ids)
+            if len(user.printer_ids) != len(groups_by_report_type):
+                raise ValidationError(
+                    _("User may have at most one default printer per group for each report type")
+                )

--- a/addons/print/tests/test_print_printer.py
+++ b/addons/print/tests/test_print_printer.py
@@ -118,16 +118,18 @@ class TestPrintPrinter(PrinterCase):
         )
         self.assertIn(self.printer_dotmatrix, self.user_alice.printer_ids)
         self.assertIn(self.user_alice, self.printer_dotmatrix.user_ids)
-        self.assertEqual(self.user_alice.printer_id, self.printer_dotmatrix)
+        self.assertEqual(self.user_alice.get_printer(self.printer_dotmatrix.report_type), self.printer_dotmatrix)
+
         self.assertEqual(Printer.sudo(self.user_alice).printers(),
                          self.printer_dotmatrix)
+
         self.printer_plotter.sudo(self.user_bob).set_user_default()
         self.assertTrue(
             self.printer_plotter.sudo(self.user_bob).is_user_default
         )
         self.assertIn(self.printer_plotter, self.user_bob.printer_ids)
         self.assertIn(self.user_bob, self.printer_plotter.user_ids)
-        self.assertEqual(self.user_bob.printer_id, self.printer_plotter)
+        self.assertEqual(self.user_bob.get_printer(self.printer_plotter.report_type), self.printer_plotter)
         self.assertEqual(Printer.sudo(self.user_bob).printers(),
                          self.printer_plotter)
         Printer.sudo(self.user_alice).spool_test_page()

--- a/addons/print/views/print_printer_views.xml
+++ b/addons/print/views/print_printer_views.xml
@@ -54,7 +54,7 @@
 	    <notebook attrs="{'invisible':[('is_group','=',False)]}">
 	      <page string="Grouped Printers">
 		<field name="child_ids"
-		       context="{'default_group_id': active_id}"/>
+		       context="{'default_group_id': active_id, 'default_report_type': report_type}"/>
 	      </page>
 	    </notebook>
 	  </sheet>


### PR DESCRIPTION
Allow one user default printer per report type.

Updated unit test test06_user_default.

Added unit test for one user default printer group per report type.