### PR TITLE
Story/1824 Mobile UI: Improve Odoo printing logic

### DIFF
--- a/addons/print/models/print_printer.py
+++ b/addons/print/models/print_printer.py
@@ -100,7 +100,14 @@ class Printer(models.Model):
             self.env.ref("print.default_printer").is_default = True
 
     def printers(self, report_type=None, raise_if_not_found=False):
-        """Determine printers to use"""
+        """
+        Purpose: Determine printers to use for a given report type. If no printers are found
+        for the given report type, and raise_if_not_found flag is set, then raise an error message. 
+        If called on any emtpy print.printer() recordset this method will return the system default printer. If
+        called on a non-empty print.printer() recordset this method will return suitable printers for a given report
+        type.
+        Returns: print.printer()
+        """
         if self:
             # Printers are specified in self
             printers = self
@@ -177,52 +184,26 @@ class Printer(models.Model):
         return True
 
     def spool_report(self, docids, report_name, data=None, title=None, copies=1):
-        """Spool report to printer"""
+        """
+        Purpose: This function will render and spool the report to the printer that it
+        is called on, as long as the printer has a report_type attribute matching that of the desired 
+        report.
+        Return: boolean
+        """
         # pylint: disable=too-many-arguments, too-many-locals
 
         if copies <= 0:
             _logger.info(_("Zero or fewer copies requested, nothing will be printed."))
             return True
 
-        # Identify reports
-        if isinstance(report_name, models.BaseModel):
-            reports = report_name
-        else:
-            name = report_name
-            Report = self.env["ir.actions.report"]
-            reports = Report._get_report_from_name(name)
-            if not reports:
-                reports = self.env.ref(name, raise_if_not_found=False)
-            if not reports:
-                raise UserError(_("Undefined report %s") % name)
+        reports = self._fetch_reports_for_printing(report_name)
 
-        # Identify required report types
-        report_types = set(reports.mapped("report_type"))
+        required_report_types = set(reports.mapped("report_type"))
 
-        # If there is only 1 report type to print out then raise an error if printer not found,
-        # otherwise continue checking for other report types
-        printer_raise_if_not_found = len(report_types) == 1
+        printers_by_report_type = self._assign_printers_to_report(required_report_types)
 
-        # Identify printer to use for each report type, only include report type in dictionary
-        # if a printer is identified
-        printers_by_report_type = {
-            rt: p
-            for rt in report_types
-            for p in (self.printers(raise_if_not_found=printer_raise_if_not_found, report_type=rt))
-            if p
-        }
-
-        if printers_by_report_type:
-            required_types = set(printers_by_report_type.keys())
-            missing = required_types - report_types
-        else:
-            missing = report_types
-
-        if missing:
-            # Get labels of missing report types from selection list
-            missing_labels = [self.get_report_type_label(rt) for rt in missing]
-            raise UserError(_("Missing reports of types: %s") % ", ".join(missing_labels))
-
+        self._check_every_report_type_has_printer(printers_by_report_type, required_report_types)
+        
         # CPCL reports require number of copies passed into the template via data
         cpcl_data = {"copies": copies}
         if data:
@@ -243,22 +224,81 @@ class Printer(models.Model):
             printer.spool(document, title=title, copies=copies)
 
         return True
+    
+    def _fetch_reports_for_printing(self, report_name):
+        """
+        Purpose: If the report name is a string, fetch the report from the data. If it is a
+        recordset return the recordset.
+        Return: ir.actions.report()
+        """
+        if isinstance(report_name, models.BaseModel):
+            reports = report_name
+        else:
+            name = report_name
+            Report = self.env["ir.actions.report"]
+            reports = Report._get_report_from_name(name)
+            if not reports:
+                reports = self.env.ref(name, raise_if_not_found=False)
+            if not reports:
+                raise UserError(_("Undefined report %s") % name)
+        return reports
+    
+    def _assign_printers_to_report(self, required_report_types):
+        """
+        Purpose: Assign each printer in self (or system default if self is empty) to a given 
+        report type. 
+        Return: dict{ ir.action.report() : print.printer() }
+        """
+        printer_raise_if_not_found = len(required_report_types) == 1
+        printers_by_report_type = {
+            rt: p
+            for rt in required_report_types
+            for p in (self.printers(rt, printer_raise_if_not_found))
+            if p
+        }
+        return printers_by_report_type
+    
+    def _check_every_report_type_has_printer(self, printers_by_report_type, required_report_types):
+        """
+        Purpose: Check which report types are missing, if any are missing raise an error. Must raise an
+        error as can't print the given report type.
+        Return: Boolean 
+        """
+        if printers_by_report_type:
+            report_types_found = set(printers_by_report_type.keys())
+            missing = required_report_types - report_types_found 
+        else:
+            missing = required_report_types
+
+        if missing:
+            missing_labels = [self.get_report_type_label(rt) for rt in missing]
+            raise UserError(_("Missing reports of types: %s") % ", ".join(missing_labels))
+        
+        return True
 
     @api.model
-    def test_page_report(self):
-        """Get printer test pages"""
+    def test_page_report(self, report_type):
+        """
+        Purpose: Search for the printer report test pages.
+        Return: ir.actions.report() 
+        """
         Report = self.env["ir.actions.report"]
+        test_page = f'print.report_test_page_{report_type}'
         return Report.sudo().search(
             [
                 ("model", "=", "print.printer"),
-                ("report_name", "=like", "print.%"),
+                ("report_name", "=", test_page),
             ]
         )
 
     def spool_test_page(self):
-        """Print test page"""
+        """
+        Purpose: Print test page for all printers in self.
+        Return: boolean
+        """
         for printer in self.printers(raise_if_not_found=True):
-            printer.spool_report(printer.ids, self.test_page_report(), title="Test page")
+            report_type_string = printer.report_type.replace("qweb-", "")
+            printer.spool_report(printer.ids, self.test_page_report(report_type_string), title="Test page")
         return True
 
     def clear_user_default(self):

--- a/addons/print/models/print_printer.py
+++ b/addons/print/models/print_printer.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import subprocess
+from collections import defaultdict
 from odoo import api, fields, models
 from odoo.tools.translate import _
 from odoo.tools.misc import find_in_path
@@ -209,19 +210,17 @@ class Printer(models.Model):
         if data:
             cpcl_data.update(data)
 
-        # Generate reports for each required report type
-        documents = {
-            r.report_type: (
-                ("%s %s" % (r.name, str(docids))) if title is None else title,
-                r._render(docids, cpcl_data if r.report_type == "qweb-cpcl" else data)[0],
-            )
-            for r in reports
-        }
+        # Generate dictionary with {report type: [(title, *rendered_document*), ...]} for each report type
+        documents = defaultdict(list)
+        for report in reports: 
+            documents[report.report_type].append((
+                ("%s %s" % (report.name, str(docids))) if title is None else title,
+                report._render(docids, cpcl_data if report.report_type == "qweb-cpcl" else data)[0],))
 
-        # Send appropriate report to each printer
+        # Send rendered doc for each report type to printer
         for report_type, printer in printers_by_report_type.items():
-            title, document = documents[report_type]
-            printer.spool(document, title=title, copies=copies)
+            for title, document in documents[report_type]:
+                printer.spool(document, title=title, copies=copies)
 
         return True
     

--- a/addons/print/models/print_printer.py
+++ b/addons/print/models/print_printer.py
@@ -32,11 +32,9 @@ class Printer(models.Model):
     _rec_name = "full_name"
 
     name = fields.Char(string="Name", required=True)
-    full_name = fields.Char(
-        string="Full Name", compute="_compute_full_name", store=True, 
-    )
-    barcode = fields.Char(string="Barcode", )
-    queue = fields.Char(string="Print Queue Name", )
+    full_name = fields.Char(string="Full Name", compute="_compute_full_name", store=True)
+    barcode = fields.Char(string="Barcode")
+    queue = fields.Char(string="Print Queue Name")
     report_type = fields.Selection(
         [("qweb-pdf", "PDF"), ("qweb-html", "HTML"), ("qweb-cpcl", "CPCL/XML")],
         string="Report Type",
@@ -102,8 +100,8 @@ class Printer(models.Model):
 
     def printers(self, report_type=None, raise_if_not_found=False):
         """
-        Purpose: Determine printers to use for a given report type. If no printers are found
-        for the given report type, and raise_if_not_found flag is set, then raise an error message. 
+        Determine printers to use for a given report type. If no printers are found
+        for the given report type, and raise_if_not_found flag is set, then raise an error message.
         If called on any emtpy print.printer() recordset this method will return the system default printer. If
         called on a non-empty print.printer() recordset this method will return suitable printers for a given report
         type.
@@ -186,8 +184,8 @@ class Printer(models.Model):
 
     def spool_report(self, docids, report_name, data=None, title=None, copies=1):
         """
-        Purpose: This function will render and spool the report to the printer that it
-        is called on, as long as the printer has a report_type attribute matching that of the desired 
+        This function will render and spool the report to the printer that it
+        is called on, as long as the printer has a report_type attribute matching that of the desired
         report.
         Return: boolean
         """
@@ -198,13 +196,10 @@ class Printer(models.Model):
             return True
 
         reports = self._fetch_reports_for_printing(report_name)
-
         required_report_types = set(reports.mapped("report_type"))
-
         printers_by_report_type = self._assign_printers_to_report(required_report_types)
-
         self._check_every_report_type_has_printer(printers_by_report_type, required_report_types)
-        
+
         # CPCL reports require number of copies passed into the template via data
         cpcl_data = {"copies": copies}
         if data:
@@ -212,10 +207,12 @@ class Printer(models.Model):
 
         # Generate dictionary with {report type: [(title, *rendered_document*), ...]} for each report type
         documents = defaultdict(list)
-        for report in reports: 
-            documents[report.report_type].append((
-                ("%s %s" % (report.name, str(docids))) if title is None else title,
-                report._render(docids, cpcl_data if report.report_type == "qweb-cpcl" else data)[0],))
+        for report in reports:
+            doc_title = title or ("%s %s" % (report.name, str(docids)))
+            rendered_doc = report._render(
+                docids, cpcl_data if report.report_type == "qweb-cpcl" else data
+            )[0]
+            documents[report.report_type].append((doc_title, rendered_doc))
 
         # Send rendered doc for each report type to printer
         for report_type, printer in printers_by_report_type.items():
@@ -223,10 +220,10 @@ class Printer(models.Model):
                 printer.spool(document, title=title, copies=copies)
 
         return True
-    
+
     def _fetch_reports_for_printing(self, report_name):
         """
-        Purpose: If the report name is a string, fetch the report from the data. If it is a
+        If the report name is a string, fetch the report from the data. If it is a
         recordset return the recordset.
         Return: ir.actions.report()
         """
@@ -241,11 +238,11 @@ class Printer(models.Model):
             if not reports:
                 raise UserError(_("Undefined report %s") % name)
         return reports
-    
+
     def _assign_printers_to_report(self, required_report_types):
         """
-        Purpose: Assign each printer in self (or system default if self is empty) to a given 
-        report type. 
+        Assign each printer in self (or system default if self is empty) to a given
+        report type.
         Return: dict{ ir.action.report() : print.printer() }
         """
         printer_raise_if_not_found = len(required_report_types) == 1
@@ -256,33 +253,33 @@ class Printer(models.Model):
             if p
         }
         return printers_by_report_type
-    
+
     def _check_every_report_type_has_printer(self, printers_by_report_type, required_report_types):
         """
-        Purpose: Check which report types are missing, if any are missing raise an error. Must raise an
+        Check which report types are missing, if any are missing raise an error. Must raise an
         error as can't print the given report type.
-        Return: Boolean 
+        Return: Boolean
         """
         if printers_by_report_type:
             report_types_found = set(printers_by_report_type.keys())
-            missing = required_report_types - report_types_found 
+            missing = required_report_types - report_types_found
         else:
             missing = required_report_types
 
         if missing:
             missing_labels = [self.get_report_type_label(rt) for rt in missing]
             raise UserError(_("Missing reports of types: %s") % ", ".join(missing_labels))
-        
+
         return True
 
     @api.model
     def test_page_report(self, report_type):
         """
-        Purpose: Search for the printer report test pages.
-        Return: ir.actions.report() 
+        Search for the printer report test pages.
+        Return: ir.actions.report()
         """
         Report = self.env["ir.actions.report"]
-        test_page = f'print.report_test_page_{report_type}'
+        test_page = f"print.report_test_page_{report_type}"
         return Report.sudo().search(
             [
                 ("model", "=", "print.printer"),
@@ -292,12 +289,14 @@ class Printer(models.Model):
 
     def spool_test_page(self):
         """
-        Purpose: Print test page for all printers in self.
+        Print test page for all printers in self.
         Return: boolean
         """
         for printer in self.printers(raise_if_not_found=True):
             report_type_string = printer.report_type.replace("qweb-", "")
-            printer.spool_report(printer.ids, self.test_page_report(report_type_string), title="Test page")
+            printer.spool_report(
+                printer.ids, self.test_page_report(report_type_string), title="Test page"
+            )
         return True
 
     def clear_user_default(self):

--- a/addons/print/models/print_printer.py
+++ b/addons/print/models/print_printer.py
@@ -198,7 +198,6 @@ class Printer(models.Model):
         reports = self._fetch_reports_for_printing(report_name)
         required_report_types = set(reports.mapped("report_type"))
         printers_by_report_type = self._assign_printers_to_report(required_report_types)
-        self._check_every_report_type_has_printer(printers_by_report_type, required_report_types)
 
         # CPCL reports require number of copies passed into the template via data
         cpcl_data = {"copies": copies}
@@ -209,9 +208,8 @@ class Printer(models.Model):
         documents = defaultdict(list)
         for report in reports:
             doc_title = title or ("%s %s" % (report.name, str(docids)))
-            rendered_doc = report._render(
-                docids, cpcl_data if report.report_type == "qweb-cpcl" else data
-            )[0]
+            report_data = cpcl_data if report.report_type == "qweb-cpcl" else data
+            rendered_doc = report._render(docids, report_data)[0]
             documents[report.report_type].append((doc_title, rendered_doc))
 
         # Send rendered doc for each report type to printer
@@ -242,35 +240,17 @@ class Printer(models.Model):
     def _assign_printers_to_report(self, required_report_types):
         """
         Assign each printer in self (or system default if self is empty) to a given
-        report type.
+        report type. If the printer is missing for a given report type, then the report
+        type can't be printed, and an Error must be raised.
         Return: dict{ ir.action.report() : print.printer() }
         """
-        printer_raise_if_not_found = len(required_report_types) == 1
         printers_by_report_type = {
             rt: p
             for rt in required_report_types
-            for p in (self.printers(rt, printer_raise_if_not_found))
+            for p in (self.printers(rt, True))
             if p
         }
         return printers_by_report_type
-
-    def _check_every_report_type_has_printer(self, printers_by_report_type, required_report_types):
-        """
-        Check which report types are missing, if any are missing raise an error. Must raise an
-        error as can't print the given report type.
-        Return: Boolean
-        """
-        if printers_by_report_type:
-            report_types_found = set(printers_by_report_type.keys())
-            missing = required_report_types - report_types_found
-        else:
-            missing = required_report_types
-
-        if missing:
-            missing_labels = [self.get_report_type_label(rt) for rt in missing]
-            raise UserError(_("Missing reports of types: %s") % ", ".join(missing_labels))
-
-        return True
 
     @api.model
     def test_page_report(self, report_type):

--- a/addons/print/report/test_page_reports.xml
+++ b/addons/print/report/test_page_reports.xml
@@ -2,11 +2,11 @@
 <odoo>
   <data>
 
-    <record id="action_report_test_page" model="ir.actions.report">
-      <field name="name">print.report_test_page</field>
+    <record id="action_report_test_page_pdf" model="ir.actions.report">
+      <field name="name">print.report_test_page_pdf</field>
       <field name="model">print.printer</field>
       <field name="report_type">qweb-pdf</field>
-      <field name="report_name">print.report_test_page</field>
+      <field name="report_name">print.report_test_page_pdf</field>
       <field name="print_report_name">Printer Test Page (PDF)</field>
     </record>
 

--- a/addons/print/report/test_page_templates.xml
+++ b/addons/print/report/test_page_templates.xml
@@ -3,7 +3,7 @@
   <data>
 
     <!-- Printer Test Page template (PDF) -->
-    <template id="report_test_page">
+    <template id="report_test_page_pdf">
       <t t-call="web.html_container">
 		<t t-foreach="docs" t-as="o">
 	  		<t t-call="web.external_layout">

--- a/addons/print/tests/common.py
+++ b/addons/print/tests/common.py
@@ -228,7 +228,7 @@ class ActionPrintCase(PrinterCase):
     @property
     def default_report(self):
         """Return the default report"""
-        return self.env.ref("print.action_report_test_page")
+        return self.env.ref("print.action_report_test_page_pdf")
 
     @property
     def default_printer(self):

--- a/addons/print/tests/test_print_printer.py
+++ b/addons/print/tests/test_print_printer.py
@@ -252,7 +252,9 @@ class TestPrintPrinter(PrinterCase):
 
     def test_xmlid(self):
         """Test ability to use XML ID to identify a report"""
-        self.printer_default.spool_report(self.printer_default.ids, "print.action_report_test_page_pdf")
+        self.printer_default.spool_report(
+            self.printer_default.ids, "print.action_report_test_page_pdf"
+        )
         self.assertPrintedLpr("-T", ANY)
 
     def test_non_pdf(self):
@@ -442,7 +444,7 @@ class TestPrintPrinter(PrinterCase):
                         "INFO:odoo.addons.print.models.print_printer:Zero or fewer copies requested, nothing will be printed."
                     ],
                 )
-    
+
     def test_multiple_reports_of_same_report_type_get_printed(self):
         """
         Test there are 5 calls to the printer when there are multiple reports with the same
@@ -451,6 +453,7 @@ class TestPrintPrinter(PrinterCase):
         IrActionReport = self.env["ir.actions.report"]
         pdf_reports = IrActionReport.search([("report_type", "=", "qweb-pdf")])
         pdf_reports = pdf_reports.with_context(force_report_rendering=True)
-        self.printer_default.with_context(force_report_rendering=True).spool_report(self.printer_default.ids, pdf_reports)
-        self.assertPrintedLprMulti(["-T", ANY],["-T", ANY] ,["-T", ANY],["-T", ANY],["-T", ANY])
-        
+        self.printer_default.with_context(force_report_rendering=True).spool_report(
+            self.printer_default.ids, pdf_reports
+        )
+        self.assertPrintedLprMulti(["-T", ANY], ["-T", ANY], ["-T", ANY], ["-T", ANY], ["-T", ANY])

--- a/addons/print/tests/test_print_printer.py
+++ b/addons/print/tests/test_print_printer.py
@@ -442,3 +442,15 @@ class TestPrintPrinter(PrinterCase):
                         "INFO:odoo.addons.print.models.print_printer:Zero or fewer copies requested, nothing will be printed."
                     ],
                 )
+    
+    def test_multiple_reports_of_same_report_type_get_printed(self):
+        """
+        Test there are 5 calls to the printer when there are multiple reports with the same
+        report type
+        """
+        IrActionReport = self.env["ir.actions.report"]
+        pdf_reports = IrActionReport.search([("report_type", "=", "qweb-pdf")])
+        pdf_reports = pdf_reports.with_context(force_report_rendering=True)
+        self.printer_default.with_context(force_report_rendering=True).spool_report(self.printer_default.ids, pdf_reports)
+        self.assertPrintedLprMulti(["-T", ANY],["-T", ANY] ,["-T", ANY],["-T", ANY],["-T", ANY])
+        

--- a/addons/print/tests/test_print_printer.py
+++ b/addons/print/tests/test_print_printer.py
@@ -151,7 +151,7 @@ class TestPrintPrinter(PrinterCase):
     def test_title(self):
         """Test specifying job title"""
         Report = self.env["ir.actions.report"]
-        report = Report._get_report_from_name("print.report_test_page").with_context(
+        report = Report._get_report_from_name("print.report_test_page_pdf").with_context(
             force_report_rendering=True
         )
 
@@ -161,7 +161,7 @@ class TestPrintPrinter(PrinterCase):
     def test_copies(self):
         """Test specifying number of copies"""
         Report = self.env["ir.actions.report"]
-        report = Report._get_report_from_name("print.report_test_page").with_context(
+        report = Report._get_report_from_name("print.report_test_page_pdf").with_context(
             force_report_rendering=True
         )
 
@@ -252,16 +252,16 @@ class TestPrintPrinter(PrinterCase):
 
     def test_xmlid(self):
         """Test ability to use XML ID to identify a report"""
-        self.printer_default.spool_report(self.printer_default.ids, "print.action_report_test_page")
+        self.printer_default.spool_report(self.printer_default.ids, "print.action_report_test_page_pdf")
         self.assertPrintedLpr("-T", ANY)
 
     def test_non_pdf(self):
         """Test ability to send non-PDF data to printer"""
         Report = self.env["ir.actions.report"]
-        report = Report._get_report_from_name("print.report_test_page")
+        report = Report._get_report_from_name("print.report_test_page_pdf")
         report.report_type = "qweb-html"
         self.printer_default.report_type = "qweb-html"
-        self.printer_default.spool_test_page()
+        self.printer_default.spool_report(self.printer_default.ids, report)
         self.assertPrintedLpr("-T", ANY, mimetype=HTML_MIMETYPE)
 
     def test_cpcl(self):
@@ -271,7 +271,7 @@ class TestPrintPrinter(PrinterCase):
 
     def test_spool_by_record(self):
         """Test spooling ir.actions.report record (rather than report name)"""
-        report = self.env.ref("print.action_report_test_page")
+        report = self.env.ref("print.action_report_test_page_pdf")
         report = report.with_context(force_report_rendering=True)
         self.printer_default.spool_report(self.printer_default.ids, report)
         self.assertPrintedLpr("-T", ANY)
@@ -432,7 +432,7 @@ class TestPrintPrinter(PrinterCase):
                     "odoo.addons.print.models.print_printer", level=logging.INFO
                 ) as cm:
                     self.printer_default.spool_report(
-                        self.printer_default.ids, "print.report_test_page", copies=num_copies
+                        self.printer_default.ids, "print.report_test_page_pdf", copies=num_copies
                     )
                     self.mock_subprocess.Popen.assert_not_called()
                     self.mock_subprocess.Popen.reset_mock()

--- a/addons/print/tests/test_print_printer.py
+++ b/addons/print/tests/test_print_printer.py
@@ -371,7 +371,7 @@ class TestPrintPrinter(PrinterCase):
         self.printer_default.report_type = "qweb-cpcl"
         with self.assertRaises(UserError):
             self.printer_default.spool_report(
-                self.printer_default.ids, "print.action_report_test_page"
+                self.printer_default.ids, "print.action_report_test_page_pdf"
             )
 
     def test_ephemeral(self):


### PR DESCRIPTION
The print logic in odoo_print has been changed such that the missing report types are reported on properly. Unit tests were adjusted for this change. 

I also spotted that spool_report() would output the wrong thing if fed multiple reports of the same report_type. So I fixed it, and added a unit test for it. 

I also refactored the spool_report() method to make it easier to follow. 