### PR TITLE
Se 147

### DIFF
--- a/addons/print/controllers/main.py
+++ b/addons/print/controllers/main.py
@@ -12,5 +12,32 @@ class Session(controllers.main.Session):
         """Logout"""
         uid = http.request.session.uid
         if uid is not None:
-            http.request.env['print.printer'].with_user(uid).clear_ephemeral()
+            http.request.env["print.printer"].with_user(uid).clear_ephemeral()
         return super().logout(*args, **kwargs)
+
+
+class PrintAuditLogAction(controllers.main.Action):
+    @http.route()
+    def load(self, action_id, additional_context=None):
+        """
+        Extend load to log a note in the audit trail
+        of the affected records when a report is printed.
+        Only affects models who have the class attribute AUDIT_LOG_PRINTING set to True.
+
+        NB: If setting this class attribute on models,
+        ensure the model has `_inherit = ["mail.thread"]`
+        """
+        IrModel = http.request.env["ir.model"]
+        res = super().load(action_id, additional_context=additional_context)
+        if res.get("binding_type") == "report":
+            binding_model = res.get("binding_model_id")
+            if binding_model:
+                # `binding_model`` is a tuple of the model id and display name
+                # `.model` gives us the models _name which we can pass into it to get an emptyset.
+                model = http.request.env[IrModel.browse(binding_model[0]).model]
+                if hasattr(model, "AUDIT_LOG_PRINTING") and model.AUDIT_LOG_PRINTING:
+                    for record in model.browse(http.request.env.context.get("active_ids")):
+                        record.message_post(
+                            body=f"Report [{res.get('name')}] Printed from the Desktop."
+                        )
+        return res

--- a/addons/print/models/ir_actions_print.py
+++ b/addons/print/models/ir_actions_print.py
@@ -64,6 +64,17 @@ class IrActionsPrint(models.Model):
                     active_id,
                 )
                 printer.spool_report(records.ids, report)
+                # Log a note in the audit trail
+                # of the affected records when a report is direct printed.
+                # Only affects models who have the class attribute AUDIT_LOG_PRINTING set to True.
+
+                # NB: If setting this class attribute on models,
+                # ensure the model has `_inherit = ["mail.thread"]`
+                if hasattr(obj, "AUDIT_LOG_PRINTING") and obj.AUDIT_LOG_PRINTING:
+                    for record in records:
+                        record.message_post(
+                            body=f"Report [{report.name}] Printed from Print Strategy [{strategy.name}]."
+                        )
 
 
 class PrintStrategy(models.Model):


### PR DESCRIPTION
[print: Extend automated printing hook]

When an automated print action occurrs, log a note in the audit
trail of the records which were printed. Only do this if
the class attribute AUDIT_LOG_PRINTING exists and is set to True

[print: Extend web load controller]

When a desktop print action occurrs, log a note in the audit
trail of the records which were printed. Only do this if
the class attribute AUDIT_LOG_PRINTING exists and is set to True